### PR TITLE
escape json on html renderer

### DIFF
--- a/lib/renderers.js
+++ b/lib/renderers.js
@@ -2,6 +2,7 @@
 
 const xml = require("tiny-xml"),
 	yaml = require("yamljs"),
+	html = require("escape-html"),
 	path = require("path"),
 	csv = require("csv.js"),
 	iterate = require(path.join(__dirname, "iterate.js")),
@@ -40,7 +41,7 @@ renderers.set("text/html", (arg, req, headers, tpl) => {
 		.replace("{{formats}}", "<option value=''></option>" + Array.from(renderers.keys()).filter(i => i.indexOf("html") === -1).map(i => {
 			return "<option value='" + i + "'>" + i.replace(/^.*\//, "").toUpperCase() + "</option>";
 		}).join("\n"))
-		.replace("{{body}}", JSON.stringify(arg, null, 2))
+		.replace("{{body}}", html(JSON.stringify(arg, null, 2)))
 		.replace("{{year}}", new Date().getFullYear())
 		.replace("{{version}}", req.server.config.version)
 		.replace("{{allow}}", headers.allow)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "connect-redis": "~3.3.0",
     "cookie-parser": "~1.4.3",
     "csv.js": "~1.0.2",
+    "escape-html": "^1.0.3",
     "express-session": "~1.15.3",
     "keysort": "~1.0.2",
     "lusca": "~1.4.1",

--- a/test/renderers_test.js
+++ b/test/renderers_test.js
@@ -75,6 +75,14 @@ describe("Renderers", function () {
 			.end();
 	});
 
+	it("GET HTML (body)", function () {
+		return tinyhttptest({url: "http://localhost:" + port + "/html?format=text/html"})
+			.expectStatus(200)
+			.expectHeader("content-type", "text/html")
+			.expectBody(/^([^](?!<\/html>))*[^]<\/html>[\n\r\s]*$/gi)
+			.end();
+	});
+
 	it("GET YAML (header)", function () {
 		return tinyhttptest({url: "http://localhost:" + port, headers: {accept: "application/yaml"}})
 			.expectStatus(200)

--- a/test/routes.js
+++ b/test/routes.js
@@ -28,6 +28,9 @@ module.exports.get = {
 		14,
 		15
 	],
+	"/html": [
+		"</body></html>"
+	],
 	"/test": "Get to the chopper!",
 	"/test/:hidden": function (req, res) {
 		res.send(req.params.hidden);


### PR DESCRIPTION
JSON containing HTML (or even XML) can break browseable API markup.

* Apply escape-html to JSON on ``text/html`` renderer.
* Add test: returned ``</html>`` does not break browseable API's HTML.